### PR TITLE
fix: bump CI's Java version to match the rest of the modules

### DIFF
--- a/.github/workflows/Base-Publish.yml
+++ b/.github/workflows/Base-Publish.yml
@@ -43,7 +43,7 @@ jobs:
       - uses: actions/setup-java@v4
         with:
           distribution: "adopt"
-          java-version: 17
+          java-version: 21
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4


### PR DESCRIPTION
Very nice project, some pretty amazing ideas. Tried it out today and noticed that even though the source and target compatibility for most modules is targeting Java 21, the CI is still running 17, and for that it fails to run the action if you have just created a new project. Figured i'd send up a patch.