### PR TITLE
Add permissions to KMMBridge-Debug

### DIFF
--- a/.github/workflows/KMMBridge-Debug.yml
+++ b/.github/workflows/KMMBridge-Debug.yml
@@ -3,6 +3,10 @@ name: KMMBridge-Debug
 on:
   workflow_dispatch:
 
+permissions:
+  contents: write
+  packages: write
+
 jobs:
   call-publish:
     uses: ./.github/workflows/Base-Publish.yml


### PR DESCRIPTION
I needed to add these permissions for my GitHub workflow to start. 

Additionally, I had this error:

```
[Invalid workflow file: .github/workflows/KMMBridge-Debug.yml#L7](https://github.com/jQrgen/KMMBridgeSMPQuickStart/actions/runs/21545958102/workflow)
The workflow is not valid. .github/workflows/KMMBridge-Debug.yml (Line: 7, Col: 3): Error calling workflow 'jQrgen/KMMBridgeSMPQuickStart/.github/workflows/Base-Publish.yml@8d639e43016ede39c2c073961abb235d1e4639e7'. The workflow is requesting 'contents: write, packages: write', but is only allowed 'contents: read, packages: read'.
```

You can see for yourself here: https://github.com/jQrgen/KMMBridgeSMPQuickStart/actions/runs/21545958102

Adding the permissions in this pull request allowed my build to start: https://github.com/jQrgen/KMMBridgeSMPQuickStart/actions/runs/21546061130